### PR TITLE
Fix actualBalance to only include accepted transactions

### DIFF
--- a/src/HasWallet.php
+++ b/src/HasWallet.php
@@ -119,10 +119,12 @@ trait HasWallet
     {
         $credits = $this->wallet->transactions()
             ->whereIn('type', ['deposit', 'refund'])
+            ->where('accepted', 1)
             ->sum('amount');
 
         $debits = $this->wallet->transactions()
             ->whereIn('type', ['withdraw', 'payout'])
+            ->where('accepted', 1)
             ->sum('amount');
 
         return $credits - $debits;


### PR DESCRIPTION
**Issue:**
`actualBalance` was including transactions that weren't accepted and so the calcualted balance for the user was incorrect.

**Work Done:**
- Added a where clause to only include accepted transactions so that the balance is calculated correctly.

fixes #1 